### PR TITLE
Add NBA 2K20, which needs Proton 5

### DIFF
--- a/steam-tweaks.yaml
+++ b/steam-tweaks.yaml
@@ -272,6 +272,9 @@
 "1248990": # Mýrdalssandur, Iceland
   compat_tool: proton_5
 
+"1089350": # NBA 2K20
+  compat_tool: proton_5
+
 "47870": # Need for Speed: Hot Pursuit
   compat_tool: proton_411
 


### PR DESCRIPTION
The commentator audio doesn't work otherwise. 