### PR TITLE
Use native version of AER Memories of Old

### DIFF
--- a/steam-tweaks.yaml
+++ b/steam-tweaks.yaml
@@ -31,8 +31,8 @@
 "371140": # Aegis Defenders
   compat_tool: proton_411
 
-"331870": # AER Memories of Old; native version displays only black screen
-  compat_tool: proton_411
+"331870": # AER Memories of Old; fix black screen in native version
+  launch_options: '%command% -screen-fullscreen 0'
 
 "951940": # Almost There: The Platformer
   compat_tool: proton_411


### PR DESCRIPTION
Running in proton is not really necessary, because a working fix for the native version is described here, which only needs an additional launch flag: https://steamcommunity.com/app/331870/discussions/0/1728701877462177731/