### PR TITLE
Fix last play time and other keys in the shortcuts.vdf file

### DIFF
--- a/steam-shortcuts
+++ b/steam-shortcuts
@@ -125,7 +125,12 @@ for d in SHORTCUT_DIRS:
     for f in os.listdir(d):
         y = open(d + '/' + f)
         dd = yaml.load(y, Loader=yaml.FullLoader)
-        data = data + dd
+        if type(dd) is list:
+            data = data + dd
+        elif type(dd) is dict:
+            data.append(dd)
+        else:
+            print("Error reading file " + d + "/" + f)  # Should not happen
 
 if len(data) == 0:
     sys.exit(1)
@@ -145,13 +150,8 @@ for user_dir in STEAM_USER_DIRS:
     shortcuts = {}
     n = 0
     shortcut = None
-    if type(data) is list:
-        for entry in data:
-            shortcut = create_shortcut(entry)
-            shortcuts[str(n)] = shortcut
-            n += 1
-    elif type(data) is dict:
-        shortcut = create_shortcut(data)
+    for entry in data:
+        shortcut = create_shortcut(entry)
         shortcuts[str(n)] = shortcut
         n += 1
 

--- a/steam-shortcuts
+++ b/steam-shortcuts
@@ -5,134 +5,126 @@ import sys
 import vdf
 import yaml
 import binascii
-import zlib
-from pycrc.algorithms import Crc
-
 
 def shortcut_app_id(exe, name):
     crc_input = ''.join([exe, name])
     return str(binascii.crc32(bytes(crc_input.encode())) & 0xFFFFFFFF | 0x80000000 - 2**32)
 
-
-def shortcut_app_id_new(exe, name):
-	crc_input = ''.join([exe, name])
-	return str((zlib.crc32(crc_input.encode()) & 0xffffffff) | 0x80000000)
-
-
 def create_shortcut(entry):
-	if 'name' not in entry:
-		print('shortcut missing required field "name"; skipping')
-		return
+    if 'name' not in entry:
+        print('shortcut missing required field "name"; skipping')
+        return
+    if 'cmd' not in entry:
+        print('shortcut missing required field "cmd"; skipping')
+        return
 
-	if 'cmd' not in entry:
-		print('shortcut missing required field "cmd"; skipping')
-		return
+    app_id = shortcut_app_id(entry['cmd'], entry['name'])
 
-	shortcut = {}
-	shortcut['AppName'] = entry['name']
-	shortcut['Exe'] = entry['cmd']
+    shortcut = {}
+    shortcut['appid'] = app_id
+    shortcut['AppName'] = entry['name']
+    shortcut['Exe'] = entry['cmd']
 
-	if 'dir' in entry:
-		shortcut['StartDir'] = entry['dir']
+    if 'dir' in entry:
+        shortcut['StartDir'] = entry['dir']
+    else:
+        shortcut['StartDir'] = "~"
 
-	if 'params' in entry:
-		shortcut['LaunchOptions'] = entry['params']
+    if 'params' in entry:
+        shortcut['LaunchOptions'] = entry['params']
 
-	if 'hidden' in entry:
-		shortcut['isHidden'] = entry['hidden']
+    if 'hidden' in entry:
+        shortcut['isHidden'] = entry['hidden']
 
-	if 'icon' in entry:
-		shortcut['icon'] = entry['icon']
+    if 'icon' in entry:
+        shortcut['icon'] = entry['icon']
 
-	shortcut['AllowDesktopConfig'] = 1
-	shortcut['AllowOverlay'] = 1
-	shortcut['OpenVR'] = 0
-	shortcut['tags'] = {}
+    shortcut['AllowDesktopConfig'] = 1
+    shortcut['AllowOverlay'] = 1
+    shortcut['OpenVR'] = 0
+    shortcut['tags'] = {}
 
-	if 'tags' in entry:
-		t = 0
-		for tag in entry['tags']:
-			shortcut['tags'][str(t)] = tag
-			t += 1
+    if 'tags' in entry:
+        t = 0
+        for tag in entry['tags']:
+            shortcut['tags'][str(t)] = tag
+            t += 1
 
-	if 'banner' in entry:
-		app_id = shortcut_app_id(entry['cmd'], entry['name'])
-		_, ext = os.path.splitext(entry['banner'])
+    if 'banner' in entry:
+        _, ext = os.path.splitext(entry['banner'])
+        for user_dir in STEAM_USER_DIRS:
+            dst_dir = user_dir + '/config/grid/'
+            if not os.path.isdir(dst_dir):
+                os.makedirs(dst_dir)
+            dst = dst_dir + app_id + ext
+            if os.path.islink(dst) or os.path.isfile(dst):
+                os.remove(dst)
+            os.symlink(entry['banner'], dst)
 
-		for user_dir in STEAM_USER_DIRS:
-			dst_dir = user_dir + '/config/grid/'
-		
-			if not os.path.isdir(dst_dir):
-				os.makedirs(dst_dir)
-			dst = dst_dir + app_id + ext
-			if os.path.islink(dst) or os.path.isfile(dst):
-				os.remove(dst)
-			os.symlink(entry['banner'], dst)
+    if 'compat_tool' in entry:
+        if app_id not in compat_data:
+            compat_data[app_id] = {}
+        compat_data[app_id]['compat_tool'] = entry['compat_tool']
+        if 'compat_config' in entry:
+            compat_data[app_id]['compat_config'] = entry['compat_config']
 
-	if 'compat_tool' in entry:
-		app_id = shortcut_app_id_new(entry['cmd'], entry['name'])
-		if app_id not in compat_data:
-			compat_data[app_id] = {}
-		compat_data[app_id]['compat_tool'] = entry['compat_tool']
-		if 'compat_config' in entry:
-			compat_data[app_id]['compat_config'] = entry['compat_config']
-	
-	return shortcut
+    return shortcut
+
 
 # Initialize all directories and files
 if 'XDG_CACHE_HOME' in os.environ:
-	CACHE_HOME = os.environ['XDG_CACHE_HOME']
+    CACHE_HOME = os.environ['XDG_CACHE_HOME']
 else:
-	CACHE_HOME = os.environ['HOME'] + '/.cache'
+    CACHE_HOME = os.environ['HOME'] + '/.cache'
 
 compat_data = {}
 COMPAT_DATA_FILE = CACHE_HOME + '/steam-shortcuts-compat.yaml'
 
 if 'XDG_DATA_HOME' in os.environ:
-	DATA_HOME = os.environ['XDG_DATA_HOME']
+    DATA_HOME = os.environ['XDG_DATA_HOME']
 else:
-	DATA_HOME = os.environ['HOME'] + '/.local/share'
+    DATA_HOME = os.environ['HOME'] + '/.local/share'
 
 DATA_HOME += '/'
 
 if not os.path.isdir(DATA_HOME + 'steam-shortcuts'):
-	os.makedirs(DATA_HOME + 'steam-shortcuts')
+    os.makedirs(DATA_HOME + 'steam-shortcuts')
 
 SHORTCUT_DIRS = [ DATA_HOME + 'steam-shortcuts' ]
 
 if os.path.isdir('/usr/share/steam-shortcuts'):
-	SHORTCUT_DIRS.append('/usr/share/steam-shortcuts')
+    SHORTCUT_DIRS.append('/usr/share/steam-shortcuts')
 
 STEAM_USER_BASE_DIR = DATA_HOME + 'Steam/userdata/'
 STEAM_USER_DIRS = []
 for d in os.listdir(STEAM_USER_BASE_DIR):
-	if d == 'anonymous':
-		continue
-	path = STEAM_USER_BASE_DIR + d
-	if os.path.isdir(path):
-		STEAM_USER_DIRS.append(path)
+    if d == 'anonymous':
+        continue
+    path = STEAM_USER_BASE_DIR + d
+    if os.path.isdir(path):
+        STEAM_USER_DIRS.append(path)
 
 shortcuts = {}
 n = 0
 for d in SHORTCUT_DIRS:
-	for f in os.listdir(d):
-		y = open(d + '/' + f)
-		data = yaml.load(y, Loader=yaml.FullLoader)
+    for f in os.listdir(d):
+        y = open(d + '/' + f)
+        data = yaml.load(y, Loader=yaml.FullLoader)
 
-		shortcut = None
-		if type(data) is list:
-			for entry in data:
-				shortcut = create_shortcut(entry)
-				shortcuts[str(n)] = shortcut
-				n += 1
-		elif type(data) is dict:
-			shortcut = create_shortcut(data)
-			shortcuts[str(n)] = shortcut
-			n += 1
+        shortcut = None
+        if type(data) is list:
+            for entry in data:
+                shortcut = create_shortcut(entry)
+                shortcuts[str(n)] = shortcut
+                n += 1
+        elif type(data) is dict:
+            shortcut = create_shortcut(data)
+            shortcuts[str(n)] = shortcut
+            n += 1
 
 
 if len(shortcuts) == 0:
-	sys.exit()
+    sys.exit()
 
 
 yaml.dump(compat_data, open(COMPAT_DATA_FILE, 'w'), default_flow_style=False)

--- a/steam-shortcuts
+++ b/steam-shortcuts
@@ -10,6 +10,20 @@ def shortcut_app_id(exe, name):
     crc_input = ''.join([exe, name])
     return str(binascii.crc32(bytes(crc_input.encode())) & 0xFFFFFFFF | 0x80000000 - 2**32)
 
+
+"""
+Returns the shortcut dictionary of the given app_id. If not found returns {}
+"""
+def match_app_id(sc, app_id):
+    for s in sc:
+        if sc[s]['appid'] == app_id:
+            return sc[s]
+    return {}
+
+"""
+Creates a new shrotcut dictionary to be written later on the shortcut file.
+If an application exists with the same app ID in the file, tries to update it.
+"""
 def create_shortcut(entry):
     if 'name' not in entry:
         print('shortcut missing required field "name"; skipping')
@@ -20,7 +34,7 @@ def create_shortcut(entry):
 
     app_id = shortcut_app_id(entry['cmd'], entry['name'])
 
-    shortcut = {}
+    shortcut = match_app_id(steam_shortcuts, int(app_id))
     shortcut['appid'] = app_id
     shortcut['AppName'] = entry['name']
     shortcut['Exe'] = entry['cmd']
@@ -110,7 +124,9 @@ for user_dir in STEAM_USER_DIRS:
     file_path = user_dir + '/config/shortcuts.vdf'
     if os.path.isfile(file_path):
         STEAM_SHORTCUT_FILE = file_path
-        steam_shortcuts = vdf.binary_load(open(STEAM_SHORTCUT_FILE, 'rb'))
+        s = vdf.binary_load(open(STEAM_SHORTCUT_FILE, 'rb'))
+        if 'shortcuts' in s:
+            steam_shortcuts = s['shortcuts']
 
 shortcuts = {}
 n = 0

--- a/steam-shortcuts
+++ b/steam-shortcuts
@@ -104,6 +104,14 @@ for d in os.listdir(STEAM_USER_BASE_DIR):
     if os.path.isdir(path):
         STEAM_USER_DIRS.append(path)
 
+# Get current shortcuts
+steam_shortcuts = {}
+for user_dir in STEAM_USER_DIRS:
+    file_path = user_dir + '/config/shortcuts.vdf'
+    if os.path.isfile(file_path):
+        STEAM_SHORTCUT_FILE = file_path
+        steam_shortcuts = vdf.binary_load(open(STEAM_SHORTCUT_FILE, 'rb'))
+
 shortcuts = {}
 n = 0
 for d in SHORTCUT_DIRS:
@@ -129,11 +137,8 @@ if len(shortcuts) == 0:
 
 yaml.dump(compat_data, open(COMPAT_DATA_FILE, 'w'), default_flow_style=False)
 
-for user_dir in STEAM_USER_DIRS:
-	file_path = user_dir + '/config/shortcuts.vdf'
-	out = {}
-	out['shortcuts'] = shortcuts
-	if os.path.isfile(file_path):
-		os.truncate(file_path, 0)
-	b = vdf.binary_dumps(out)
-	open(file_path, 'wb').write(b)
+# Write the new file
+out = {}
+out['shortcuts'] = shortcuts
+b = vdf.binary_dumps(out)
+open(STEAM_SHORTCUT_FILE, 'wb').write(b)

--- a/steam-shortcuts
+++ b/steam-shortcuts
@@ -29,37 +29,6 @@ def shortcut_app_id_new(exe, name):
 	crc_input = ''.join([exe, name])
 	return str((zlib.crc32(crc_input.encode()) & 0xffffffff) | 0x80000000)
 
-if 'XDG_CACHE_HOME' in os.environ:
-	CACHE_HOME = os.environ['XDG_CACHE_HOME']
-else:
-	CACHE_HOME = os.environ['HOME'] + '/.cache'
-
-compat_data = {}
-COMPAT_DATA_FILE = CACHE_HOME + '/steam-shortcuts-compat.yaml'
-
-if 'XDG_DATA_HOME' in os.environ:
-	DATA_HOME = os.environ['XDG_DATA_HOME']
-else:
-	DATA_HOME = os.environ['HOME'] + '/.local/share'
-
-DATA_HOME += '/'
-
-if not os.path.isdir(DATA_HOME + 'steam-shortcuts'):
-	os.makedirs(DATA_HOME + 'steam-shortcuts')
-
-SHORTCUT_DIRS = [ DATA_HOME + 'steam-shortcuts' ]
-
-if os.path.isdir('/usr/share/steam-shortcuts'):
-	SHORTCUT_DIRS.append('/usr/share/steam-shortcuts')
-
-STEAM_USER_BASE_DIR = DATA_HOME + 'Steam/userdata/'
-STEAM_USER_DIRS = []
-for d in os.listdir(STEAM_USER_BASE_DIR):
-	if d == 'anonymous':
-		continue
-	path = STEAM_USER_BASE_DIR + d
-	if os.path.isdir(path):
-		STEAM_USER_DIRS.append(path)
 
 def create_shortcut(entry):
 	if 'name' not in entry:
@@ -121,6 +90,38 @@ def create_shortcut(entry):
 	
 	return shortcut
 
+# Initialize all directories and files
+if 'XDG_CACHE_HOME' in os.environ:
+	CACHE_HOME = os.environ['XDG_CACHE_HOME']
+else:
+	CACHE_HOME = os.environ['HOME'] + '/.cache'
+
+compat_data = {}
+COMPAT_DATA_FILE = CACHE_HOME + '/steam-shortcuts-compat.yaml'
+
+if 'XDG_DATA_HOME' in os.environ:
+	DATA_HOME = os.environ['XDG_DATA_HOME']
+else:
+	DATA_HOME = os.environ['HOME'] + '/.local/share'
+
+DATA_HOME += '/'
+
+if not os.path.isdir(DATA_HOME + 'steam-shortcuts'):
+	os.makedirs(DATA_HOME + 'steam-shortcuts')
+
+SHORTCUT_DIRS = [ DATA_HOME + 'steam-shortcuts' ]
+
+if os.path.isdir('/usr/share/steam-shortcuts'):
+	SHORTCUT_DIRS.append('/usr/share/steam-shortcuts')
+
+STEAM_USER_BASE_DIR = DATA_HOME + 'Steam/userdata/'
+STEAM_USER_DIRS = []
+for d in os.listdir(STEAM_USER_BASE_DIR):
+	if d == 'anonymous':
+		continue
+	path = STEAM_USER_BASE_DIR + d
+	if os.path.isdir(path):
+		STEAM_USER_DIRS.append(path)
 
 shortcuts = {}
 n = 0

--- a/steam-shortcuts
+++ b/steam-shortcuts
@@ -4,25 +4,14 @@ import os
 import sys
 import vdf
 import yaml
+import binascii
 import zlib
 from pycrc.algorithms import Crc
 
 
 def shortcut_app_id(exe, name):
-	"""
-	Generates the app id for a given shortcut. Steam uses app ids as a unique
-	identifier for games, but since shortcuts dont have a canonical serverside
-	representation they need to be generated on the fly. The important part
-	about this function is that it will generate the same app id as Steam does
-	for a given shortcut
-	
-	Taken from https://github.com/scottrice/pysteam
-	"""
-	algorithm = Crc(width = 32, poly = 0x04C11DB7, reflect_in = True, xor_in = 0xffffffff, reflect_out = True, xor_out = 0xffffffff)
-	crc_input = ''.join([exe,name])
-	high_32 = algorithm.bit_by_bit(crc_input) | 0x80000000
-	full_64 = (high_32 << 32) | 0x02000000
-	return str(full_64)
+    crc_input = ''.join([exe, name])
+    return str(binascii.crc32(bytes(crc_input.encode())) & 0xFFFFFFFF | 0x80000000 - 2**32)
 
 
 def shortcut_app_id_new(exe, name):

--- a/steam-shortcuts
+++ b/steam-shortcuts
@@ -118,9 +118,21 @@ for d in os.listdir(STEAM_USER_BASE_DIR):
     if os.path.isdir(path):
         STEAM_USER_DIRS.append(path)
 
-# Get current shortcuts
-steam_shortcuts = {}
+# Don't scan user directories if there are no shortcuts to create
+data = []
+for d in SHORTCUT_DIRS:
+    for f in os.listdir(d):
+        y = open(d + '/' + f)
+        data = yaml.load(y, Loader=yaml.FullLoader)
+
+if len(data) == 0:
+    sys.exit(1)
+
+yaml.dump(compat_data, open(COMPAT_DATA_FILE, 'w'), default_flow_style=False)
+
+# Get current shortcuts for each user
 for user_dir in STEAM_USER_DIRS:
+    steam_shortcuts = {}
     file_path = user_dir + '/config/shortcuts.vdf'
     if os.path.isfile(file_path):
         STEAM_SHORTCUT_FILE = file_path
@@ -128,33 +140,21 @@ for user_dir in STEAM_USER_DIRS:
         if 'shortcuts' in s:
             steam_shortcuts = s['shortcuts']
 
-shortcuts = {}
-n = 0
-for d in SHORTCUT_DIRS:
-    for f in os.listdir(d):
-        y = open(d + '/' + f)
-        data = yaml.load(y, Loader=yaml.FullLoader)
-
-        shortcut = None
-        if type(data) is list:
-            for entry in data:
-                shortcut = create_shortcut(entry)
-                shortcuts[str(n)] = shortcut
-                n += 1
-        elif type(data) is dict:
-            shortcut = create_shortcut(data)
+    shortcuts = {}
+    n = 0
+    shortcut = None
+    if type(data) is list:
+        for entry in data:
+            shortcut = create_shortcut(entry)
             shortcuts[str(n)] = shortcut
             n += 1
+    elif type(data) is dict:
+        shortcut = create_shortcut(data)
+        shortcuts[str(n)] = shortcut
+        n += 1
 
-
-if len(shortcuts) == 0:
-    sys.exit()
-
-
-yaml.dump(compat_data, open(COMPAT_DATA_FILE, 'w'), default_flow_style=False)
-
-# Write the new file
-out = {}
-out['shortcuts'] = shortcuts
-b = vdf.binary_dumps(out)
-open(STEAM_SHORTCUT_FILE, 'wb').write(b)
+    # Write the new file
+    out = {}
+    out['shortcuts'] = shortcuts
+    b = vdf.binary_dumps(out)
+    open(STEAM_SHORTCUT_FILE, 'wb').write(b)

--- a/steam-shortcuts
+++ b/steam-shortcuts
@@ -16,7 +16,7 @@ Returns the shortcut dictionary of the given app_id. If not found returns {}
 """
 def match_app_id(sc, app_id):
     for s in sc:
-        if sc[s]['appid'] == app_id:
+        if int(sc[s]['appid']) == int(app_id):
             return sc[s]
     return {}
 
@@ -34,7 +34,7 @@ def create_shortcut(entry):
 
     app_id = shortcut_app_id(entry['cmd'], entry['name'])
 
-    shortcut = match_app_id(steam_shortcuts, int(app_id))
+    shortcut = match_app_id(steam_shortcuts, app_id)
     shortcut['appid'] = app_id
     shortcut['AppName'] = entry['name']
     shortcut['Exe'] = entry['cmd']

--- a/steam-shortcuts
+++ b/steam-shortcuts
@@ -16,8 +16,9 @@ Returns the shortcut dictionary of the given app_id. If not found returns {}
 """
 def match_app_id(sc, app_id):
     for s in sc:
-        if int(sc[s]['appid']) == int(app_id):
-            return sc[s]
+        if "appid" in sc[s]:
+            if (int(sc[s]['appid']) == int(app_id)):
+                return sc[s]
     return {}
 
 """

--- a/steam-shortcuts
+++ b/steam-shortcuts
@@ -124,7 +124,8 @@ data = []
 for d in SHORTCUT_DIRS:
     for f in os.listdir(d):
         y = open(d + '/' + f)
-        data = yaml.load(y, Loader=yaml.FullLoader)
+        dd = yaml.load(y, Loader=yaml.FullLoader)
+        data = data + dd
 
 if len(data) == 0:
     sys.exit(1)

--- a/steam-shortcuts
+++ b/steam-shortcuts
@@ -113,7 +113,7 @@ if os.path.isdir('/usr/share/steam-shortcuts'):
 STEAM_USER_BASE_DIR = DATA_HOME + 'Steam/userdata/'
 STEAM_USER_DIRS = []
 for d in os.listdir(STEAM_USER_BASE_DIR):
-    if d == 'anonymous':
+    if d == 'anonymous' or d == 'ac' or d == '0':
         continue
     path = STEAM_USER_BASE_DIR + d
     if os.path.isdir(path):
@@ -141,8 +141,8 @@ yaml.dump(compat_data, open(COMPAT_DATA_FILE, 'w'), default_flow_style=False)
 for user_dir in STEAM_USER_DIRS:
     steam_shortcuts = {}
     file_path = user_dir + '/config/shortcuts.vdf'
+    STEAM_SHORTCUT_FILE = file_path
     if os.path.isfile(file_path):
-        STEAM_SHORTCUT_FILE = file_path
         s = vdf.binary_load(open(STEAM_SHORTCUT_FILE, 'rb'))
         if 'shortcuts' in s:
             steam_shortcuts = s['shortcuts']


### PR DESCRIPTION
This changes the base used for a new shortcut entry.
It tries to match the `appid` of the shortcut with existing ones by Steam and if it succeeds it is used as a base for the entry. It's meant to fix #15 

This still discards any shortcut not specified in any yaml file. 